### PR TITLE
Allow user to clear sorting

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -200,7 +200,7 @@ class ColumnSorting extends BasePlugin {
       sortingState.sortOrder = this.hot.sortOrder;
     }
 
-    if (sortingState.hasOwnProperty('sortColumn') || sortingState.hasOwnProperty('sortOrder')) {
+    if (sortingState.hasOwnProperty('sortColumn') && sortingState.hasOwnProperty('sortOrder')) {
       Handsontable.hooks.run(this.hot, 'persistentStateSave', 'columnSorting', sortingState);
     }
 


### PR DESCRIPTION
Sort state should not persist on the next page load if the user clears the sort order. `sortColumn` would be present, but `sortOrder` would not, triggering the hook, which restores the previous `sortOrder` value.
